### PR TITLE
Default span name and naming helper function

### DIFF
--- a/src/test/kotlin/com/zopa/ktor/opentracing/KtorOpenTracingTest.kt
+++ b/src/test/kotlin/com/zopa/ktor/opentracing/KtorOpenTracingTest.kt
@@ -176,7 +176,7 @@ class KtorOpenTracingTest  {
                         return sqrt(i.toDouble())
                     }
 
-                    suspend fun sqrtOfIntSuspend(i: Int): Double = span("sqrtOfIntSuspend") {
+                    suspend fun sqrtOfIntSuspend(i: Int): Double = span {
                         delay(10)
                         return sqrt(i.toDouble())
                     }
@@ -211,7 +211,7 @@ class KtorOpenTracingTest  {
                     // second child span
                     assertThat(this[1].context().traceId()).isEqualTo(last().context().traceId())
                     assertThat(this[1].parentId()).isEqualTo(last().context().spanId())
-                    assertThat(this[1].operationName()).isEqualTo("sqrtOfIntSuspend")
+                    assertThat(this[1].operationName()).isEqualTo("defaultSpanName")
                 }
             }
         }

--- a/src/test/kotlin/com/zopa/ktor/opentracing/NamingUtilTest.kt
+++ b/src/test/kotlin/com/zopa/ktor/opentracing/NamingUtilTest.kt
@@ -1,0 +1,65 @@
+package com.zopa.ktor.opentracing
+
+
+import kotlinx.coroutines.runBlocking
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+class TracingUtilTest {
+    @Test
+    fun `classAndMethodName returns class and method name for method of a class`() = runBlocking<Unit> {
+        var name: String? = null
+
+        class Dog {
+            suspend fun bark() {
+                name = classAndMethodName(this, object {})
+            }
+        }
+
+        Dog().bark()
+
+        assertThat(name).isEqualTo("Dog.bark()")
+    }
+
+    @Test
+    fun `classAndMethodName in init captures class name and does not throw NullPointerException`() {
+        var name: String? = null
+
+        class Dog {
+            init {
+                name = classAndMethodName(this, object {})
+            }
+        }
+
+        Dog()
+
+        assertThat(name).isEqualTo("Dog.()")
+    }
+
+    @Test
+    fun `classAndMethodName does not return function name`() = runBlocking<Unit> {
+        var name: String? = null
+
+        suspend fun bark() {
+            name = classAndMethodName(this, object {})
+        }
+
+        bark()
+
+        assertThat(name).isEqualTo("BlockingCoroutine.invokeSuspend()")
+    }
+
+    @Test
+    fun `classAndMethodName in extension function does not return function name`() = runBlocking<Unit> {
+        var name: String? = null
+
+        fun String.toSomethingElse() {
+            name = classAndMethodName(this, object {})
+        }
+
+        "Hello world".toSomethingElse()
+
+        assertThat(name).isEqualTo("String.invoke()")
+    }
+}


### PR DESCRIPTION
This will allow span names be set automatically using reflection in `classAndMethodName` by replacing `span {` with `span(classAndMethodName(this, object {})) {` at compile time. 