### PR TITLE
Add spanNoReceiver helper function for creating spans with no receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ class UserRepository {
 
 `span` is passed an operation name and a code block, which has the `Span` as a receiver. 
 This means that any method on the `Span` interface an be called in the block, such as `setTag`, `log` or `getBaggageItem`. 
+If you do not want the span object as receiver in your method, use `spanNoReceiver` instead. 
 
 ### Client Spans
 If your application calls another service using the Ktor HTTP client, you can install the `OpenTracingClient` feature on the client to create client spans: 

--- a/src/main/kotlin/com/zopa/ktor/opentracing/Span.kt
+++ b/src/main/kotlin/com/zopa/ktor/opentracing/Span.kt
@@ -1,0 +1,28 @@
+package com.zopa.ktor.opentracing
+
+import io.opentracing.Span
+
+
+inline fun <T> span(name: String = "defaultSpanName", block: Span.() -> T): T {
+    val tracer = getGlobalTracer()
+    val span = tracer.buildSpan(name).start()
+    try {
+        tracer.scopeManager().activate(span).use { scope ->
+            return block(span)
+        }
+    } finally {
+        span.finish()
+    }
+}
+
+inline fun <T> spanNoReceiver(name: String = "defaultSpanName", block: () -> T): T {
+    val tracer = getGlobalTracer()
+    val span = tracer.buildSpan(name).start()
+    try {
+        tracer.scopeManager().activate(span).use { scope ->
+            return block()
+        }
+    } finally {
+        span.finish()
+    }
+}

--- a/src/main/kotlin/com/zopa/ktor/opentracing/utils.kt
+++ b/src/main/kotlin/com/zopa/ktor/opentracing/utils.kt
@@ -14,18 +14,6 @@ import kotlin.coroutines.coroutineContext
 
 val log = KotlinLogging.logger { }
 
-inline fun <T> span(name: String = "defaultSpanName", block: Span.() -> T): T {
-    val tracer = getGlobalTracer()
-    val span = tracer.buildSpan(name).start()
-    try {
-        tracer.scopeManager().activate(span).use { scope ->
-            return block(span)
-        }
-    } finally {
-        span.finish()
-    }
-}
-
 data class PathUuid(val path: String, val uuid: String?)
 fun String.UuidFromPath(): PathUuid {
     val match = """\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b""".toRegex().find(this)


### PR DESCRIPTION
This is useful if the passed anonymous lambda uses `this` already. 