### PR TITLE
Fix release job group id 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ test {
 publish {
     userOrg = 'fstien'
     repoName = 'ktor-opentracing'
-    groupId = 'com.zopa'
+    groupId = 'com.github.fstien'
     artifactId = 'ktor-opentracing'
     publishVersion = '0.2.1'
     desc = 'Ktor features for OpenTracing instrumentation.'


### PR DESCRIPTION
The current release job does not work with the com.zopa group id . This is a temporary solution. 