### PR TITLE
Fix server span naming bug

### DIFF
--- a/src/main/kotlin/com/zopa/ktor/opentracing/OpenTracingServer.kt
+++ b/src/main/kotlin/com/zopa/ktor/opentracing/OpenTracingServer.kt
@@ -92,8 +92,8 @@ class OpenTracingServer {
                     span.setTag(param.key, param.value.first())
                     pathWithParamsReplaced = pathWithParamsReplaced.replace(param.value.first(),  "{${param.key}}")
                 }
-                // only replace span name if sure it's correct
-                if (pathWithParamsReplaced == call.route.parent.toString()) span.setOperationName("${call.request.httpMethod.value} $pathWithParamsReplaced")
+                
+                span.setOperationName("${call.request.httpMethod.value} $pathWithParamsReplaced")
             }
 
             pipeline.intercept(tracingPhaseFinish) {

--- a/src/test/kotlin/com/zopa/ktor/opentracing/KtorOpenTracingTest.kt
+++ b/src/test/kotlin/com/zopa/ktor/opentracing/KtorOpenTracingTest.kt
@@ -79,7 +79,7 @@ class KtorOpenTracingTest {
     }
 
     @Test
-    fun `Server span name has all occurence of request param replaced with value`() = withTestApplication {
+    fun `(Bug) Server span name incorrectly has all occurrence of request param replaced with value`() = withTestApplication {
         val routePath = "/hello/there/{name}"
         val path = "/hello/there/hello"
 

--- a/src/test/kotlin/com/zopa/ktor/opentracing/KtorOpenTracingTest.kt
+++ b/src/test/kotlin/com/zopa/ktor/opentracing/KtorOpenTracingTest.kt
@@ -79,7 +79,7 @@ class KtorOpenTracingTest {
     }
 
     @Test
-    fun `Span is not renamed if param value is not unique in path`() = withTestApplication {
+    fun `Server span name has all occurence of request param replaced with value`() = withTestApplication {
         val routePath = "/hello/there/{name}"
         val path = "/hello/there/hello"
 
@@ -97,7 +97,7 @@ class KtorOpenTracingTest {
             with(mockTracer.finishedSpans()) {
                 assertThat(size).isEqualTo(1)
                 assertThat(first().parentId()).isEqualTo(0L) // no parent span
-                assertThat(first().operationName()).isEqualTo("GET /hello/there/hello")
+                assertThat(first().operationName()).isEqualTo("GET /{name}/there/{name}")
                 assertThat(first().tags().get("name")).isEqualTo("hello")
                 assertThat(first().tags().get("span.kind")).isEqualTo("server")
                 assertThat(first().tags().get("http.status_code")).isEqualTo(200)


### PR DESCRIPTION
Fixes an issue where the `call.route.parent.toString()` returns a `/(authenticate SCOPE)/` prefix to the route when the endpoint has authentication.