### PR TITLE
Intercept the call pipeline after the setup phase

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ publish {
     repoName = 'ktor-opentracing'
     groupId = 'com.github.fstien'
     artifactId = 'ktor-opentracing'
-    publishVersion = '0.3.1'
+    publishVersion = '0.3.2'
     desc = 'Ktor features for OpenTracing instrumentation.'
     website = 'https://github.com/zopaUK/ktor-opentracing'
 }

--- a/src/main/kotlin/com/zopa/ktor/opentracing/OpenTracingServer.kt
+++ b/src/main/kotlin/com/zopa/ktor/opentracing/OpenTracingServer.kt
@@ -48,7 +48,7 @@ class OpenTracingServer {
             val tracer: Tracer = getGlobalTracer()
 
             val tracingPhaseStart = PipelinePhase("OpenTracingStart")
-            pipeline.insertPhaseBefore(ApplicationCallPipeline.Features, tracingPhaseStart)
+            pipeline.insertPhaseAfter(ApplicationCallPipeline.Setup, tracingPhaseStart)
 
             val tracingPhaseFinish = PipelinePhase("OpenTracingFinish")
             pipeline.insertPhaseAfter(ApplicationCallPipeline.Fallback, tracingPhaseFinish)


### PR DESCRIPTION
This will allow users to access the server span from the CallLogging feature, resolving this issue; https://github.com/zopaUK/ktor-opentracing/issues/27